### PR TITLE
fix sdk usage in client scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "tsc": "tsc"
   },
   "devDependencies": {
-    "@wix/sdk": "^1.15.9",
     "astro": "^5.1.8",
     "knip": "^5.43.6",
     "lefthook": "^1.1.1",

--- a/packages/@wix-astro/package.json
+++ b/packages/@wix-astro/package.json
@@ -30,7 +30,7 @@
     "@cloudflare/workers-types": "^4.20241224.0",
     "@wix/blog": "^1.0.345",
     "@wix/data": "^1.0.194",
-    "@wix/sdk": "^1.15.9",
+    "@wix/sdk": "^1.15.14",
     "chalk": "^5.4.1",
     "esm-resolve": "^1.0.11",
     "globby": "^14.0.2",

--- a/packages/@wix-astro/package.json
+++ b/packages/@wix-astro/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wix/astro",
   "description": "Develop your Astro site on the Wix Platform",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "type": "module",
   "license": "MIT",
   "keywords": [

--- a/packages/@wix-astro/src/env.d.ts
+++ b/packages/@wix-astro/src/env.d.ts
@@ -7,4 +7,5 @@ declare module "astro:env/server" {
   export const WIX_CLIENT_PUBLIC_KEY: string | undefined;
   export const WIX_CLIENT_INSTANCE_ID: string | undefined;
   export const ENV_NAME: string | undefined;
+  export const WIX_SESSION_COOKIE_NAME: string;
 }

--- a/packages/@wix-astro/src/integration.ts
+++ b/packages/@wix-astro/src/integration.ts
@@ -16,11 +16,20 @@ import chalk from "chalk";
 import { outdent } from "outdent";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { wixSDKContext } from "./vite-plugins/sdk-context.js";
 export { wixBlogLoader };
 
 export type { Runtime } from "./entrypoints/server.js";
 
-export function createIntegration(): AstroIntegration {
+export function createIntegration(
+  opts: {
+    sessionCookieName?: string;
+  } = {
+    sessionCookieName: "wixSession",
+  }
+): AstroIntegration {
+  const sessionCookieName = opts.sessionCookieName ?? "wixSession";
+
   let _config: AstroConfig;
   let _buildOutput: "server" | "static";
 
@@ -129,6 +138,13 @@ export function createIntegration(): AstroIntegration {
                 access: "public",
                 context: "client",
               },
+              WIX_SESSION_COOKIE_NAME: {
+                type: "string",
+                access: "public",
+                context: "server",
+                optional: true,
+                default: opts.sessionCookieName,
+              },
             },
           },
           build: {
@@ -146,7 +162,9 @@ export function createIntegration(): AstroIntegration {
               // It's currently commented out because there are some issues with the current implementation
               // (currently the magic import is injected into any type of module, not only JS)
               // not sure if it's necessary to inject the Wix SDK context into the client bundle
-              // wixSDKContext(),
+              wixSDKContext({
+                sessionCookieName,
+              }),
             ],
           },
           image: {
@@ -231,12 +249,12 @@ export function createIntegration(): AstroIntegration {
       },
       "astro:build:done": async (buildResult) => {
         const hasPages = buildResult.pages.length > 0;
-        const buildOutputType = _buildOutput === "static"
-          ? "static"
-          : hasPages
-          ? "hybrid"
-          : "server-only";
-
+        const buildOutputType =
+          _buildOutput === "static"
+            ? "static"
+            : hasPages
+            ? "hybrid"
+            : "server-only";
 
         const moveToClientDir = async () => {
           const clientDir = path.join(_config.outDir.pathname, "client");
@@ -246,21 +264,25 @@ export function createIntegration(): AstroIntegration {
           const files = await fs.readdir(_config.outDir.pathname);
           await Promise.all(
             files
-              .filter(file => file !== "client")
-              .map(file =>
+              .filter((file) => file !== "client")
+              .map((file) =>
                 fs.rename(
                   path.join(_config.outDir.pathname, file),
                   path.join(clientDir, file)
                 )
               )
           );
-        }
+        };
 
         if (_buildOutput === "static") {
           try {
             await moveToClientDir();
-          } catch(ex) {
-            console.error(`@wix/astro failed to move files to client directory: ${(ex as Error).message}`);
+          } catch (ex) {
+            console.error(
+              `@wix/astro failed to move files to client directory: ${
+                (ex as Error).message
+              }`
+            );
             throw ex;
           }
         }

--- a/packages/@wix-astro/src/routes/auth/callback.ts
+++ b/packages/@wix-astro/src/routes/auth/callback.ts
@@ -37,7 +37,7 @@ export async function GET({ url, cookies, redirect }: APIContext) {
       () => auth.getMemberTokens(code, state, oauthData),
       {
         retries: 3,
-        onFailedAttempt: (error) => {
+        onFailedAttempt: (error: unknown) => {
           console.error("Error getting member tokens", error);
         },
       }

--- a/packages/@wix-astro/src/vite-plugins/sdk-context.ts
+++ b/packages/@wix-astro/src/vite-plugins/sdk-context.ts
@@ -1,96 +1,85 @@
 import buildResolver from "esm-resolve";
-import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadEnv, Plugin } from "vite";
 
+
 export function wixSDKContext(opts: { sessionCookieName: string }): Plugin {
-  const userLoadedEnv = loadEnv(
-    process.env["NODE_ENV"] ?? "development",
-    process.cwd(),
-    ""
-  );
+  const virtualModuleId = '@wix/sdk-context';
+  const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
   return {
-    name: "inject-wix-sdk-context",
-    enforce: "pre",
-    config() {
+    name: 'vite-plugin-sdk-context',
+    enforce: 'pre', // Ensure the plugin runs before Vite processes dependencies
+
+    config(_, { isSsrBuild }) {
+      if (isSsrBuild) return; // Skip for server-side rendering
       return {
         optimizeDeps: {
-          esbuildOptions: {
-            plugins: [
-              {
-                name: "inject-wix-sdk-context",
-                setup(build) {
-                  console.log("inside the esbuild plugin");
-                  build.onResolve({ filter: /^@wix\/sdk-context$/ }, (args) => {
-                    return {
-                      path: args.path,
-                      namespace: "inject-wix-sdk-context",
-                    };
-                  });
-
-                  const aRequire = buildResolver(
-                    fileURLToPath(import.meta.url),
-                    {
-                      resolveToAbsolute: true,
-                    }
-                  );
-
-                  const integrationDir = dirname(
-                    aRequire("@wix/astro/package.json")!
-                  );
-                  const wixSDKResolved = aRequire("@wix/sdk/client");
-                  const wixSDKAuthResolved = aRequire(
-                    "@wix/sdk/auth/site-session"
-                  );
-
-                  build.onLoad(
-                    { filter: /.*/, namespace: "inject-wix-sdk-context" },
-                    () => {
-                      return {
-                        resolveDir: integrationDir,
-                        contents: `
-                        import { createClient } from "${wixSDKResolved}";
-                        import { SiteSessionAuth } from "${wixSDKAuthResolved}";
-
-                        function getCookieAsJson(name) {
-                          const cookies = document.cookie.split('; ');
-                          const cookie = cookies.find(row => row.startsWith(\`\${name}=\`));
-
-                          if (!cookie) return null;
-
-                          try {
-                            const jsonString = decodeURIComponent(cookie.split('=')[1]);
-                            return JSON.parse(jsonString);
-                          } catch (error) {
-                            console.error('Error parsing cookie JSON:', error);
-                            return null;
-                          }
-                        }
-
-                        export const wixContext = {
-                          client: createClient({
-                            auth: SiteSessionAuth({
-                              clientId: ${JSON.stringify(
-                                userLoadedEnv["WIX_CLIENT_ID"]
-                              )},
-                              tokens: getCookieAsJson(${JSON.stringify(
-                                opts.sessionCookieName
-                              )})?.tokens,
-                            }),
-                          })
-                        };
-                      `,
-                        loader: "js",
-                      };
-                    }
-                  );
-                },
-              },
-            ],
-          },
+          exclude: [virtualModuleId], // Ensure the virtual module is not pre-bundled
         },
       };
+    },
+
+    resolveId(id, _, { ssr }) {
+      if (ssr) return null; // Skip for server-side rendering
+      if (id === virtualModuleId) {
+        return resolvedVirtualModuleId;
+      }
+      return null;
+    },
+
+    load(id) {
+      if (id === resolvedVirtualModuleId) {
+        const aRequire = buildResolver(
+          fileURLToPath(import.meta.url),
+          {
+            resolveToAbsolute: true,
+          }
+        );
+
+        const userLoadedEnv = loadEnv(
+          process.env["NODE_ENV"] ?? "development",
+          process.cwd(),
+          ""
+        );
+        const wixSDKResolved = aRequire("@wix/sdk/client");
+        const wixSDKAuthResolved = aRequire(
+          "@wix/sdk/auth/site-session"
+        );
+     
+      return `import { createClient } from "${wixSDKResolved}";
+              import { SiteSessionAuth } from "${wixSDKAuthResolved}";
+
+              function getCookieAsJson(name) {
+                const cookies = document.cookie.split('; ');
+                const cookie = cookies.find(row => row.startsWith(\`\${name}=\`));
+
+                if (!cookie) return null;
+
+                try {
+                  const jsonString = decodeURIComponent(cookie.split('=')[1]);
+                  return JSON.parse(jsonString);
+                } catch (error) {
+                  console.error('Error parsing cookie JSON:', error);
+                  return null;
+                }
+              }
+
+              export const wixContext = {
+                client: createClient({
+                  auth: SiteSessionAuth({
+                    clientId: ${JSON.stringify(
+                      userLoadedEnv["WIX_CLIENT_ID"]
+                    )},
+                    tokens: getCookieAsJson(${JSON.stringify(
+                      opts.sessionCookieName
+                    )})?.tokens,
+                  }),
+                })
+              };
+                `;
+      }
+      return null;
     },
   };
 }

--- a/packages/astro-ricos/package.json
+++ b/packages/astro-ricos/package.json
@@ -13,7 +13,7 @@
     "dist"
   ],
   "dependencies": {
-    "@wix/sdk": "^1.15.9"
+    "@wix/sdk": "^1.15.14"
   },
   "devDependencies": {
     "typescript": "^5.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,7 +1784,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@wix/astro-ricos@workspace:packages/astro-ricos"
   dependencies:
-    "@wix/sdk": "npm:^1.15.9"
+    "@wix/sdk": "npm:^1.15.14"
     typescript: "npm:^5.7.3"
   peerDependencies:
     astro: ^5.1.8
@@ -1802,7 +1802,7 @@ __metadata:
     "@types/node": "npm:^20.9.0"
     "@wix/blog": "npm:^1.0.345"
     "@wix/data": "npm:^1.0.194"
-    "@wix/sdk": "npm:^1.15.9"
+    "@wix/sdk": "npm:^1.15.14"
     chalk: "npm:^5.4.1"
     esm-resolve: "npm:^1.0.11"
     globby: "npm:^14.0.2"
@@ -2059,7 +2059,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@wix/headless-integrations@workspace:."
   dependencies:
-    "@wix/sdk": "npm:^1.15.9"
     astro: "npm:^5.1.8"
     knip: "npm:^5.43.6"
     lefthook: "npm:^1.1.1"
@@ -2295,10 +2294,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wix/monitoring-types@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@wix/monitoring-types@npm:0.5.0"
-  checksum: 10c0/0a5cb43c443cef12f9b1cabb50147b02abe5950b16e004d6fca0a8a43602c0c850a8298a48f67b5f448b983bf4bd003fbd0767126066ce5c9684e7b21601de0a
+"@wix/monitoring-types@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@wix/monitoring-types@npm:0.9.0"
+  checksum: 10c0/78b6896479f145992e0280bc647bcb9d5ccf4261118ccc4193dadec71c3a3479a9cb8659800d2e534ce8692c8bcdfb59ff9d525c73b6d184ae9d15fadd2470be
   languageName: node
   linkType: hard
 
@@ -2408,59 +2407,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wix/sdk-context@npm:^0.0.1":
+"@wix/sdk-context@npm:0.0.1":
   version: 0.0.1
   resolution: "@wix/sdk-context@npm:0.0.1"
   checksum: 10c0/526386178321a4ce42c8ed758dcaf84eec452b31e7e1bd75cae97e029ee08ef3d3b7e16fa0c9aedf51799619329d97206d8c0a6874ce26f017d66119432d4a46
   languageName: node
   linkType: hard
 
-"@wix/sdk-runtime@npm:0.3.32":
-  version: 0.3.32
-  resolution: "@wix/sdk-runtime@npm:0.3.32"
+"@wix/sdk-runtime@npm:0.3.38, @wix/sdk-runtime@npm:^0.3.22, @wix/sdk-runtime@npm:^0.3.33":
+  version: 0.3.38
+  resolution: "@wix/sdk-runtime@npm:0.3.38"
   dependencies:
-    "@wix/sdk-context": "npm:^0.0.1"
-    "@wix/sdk-types": "npm:^1.13.3"
-  checksum: 10c0/5cd8e3db69c7d73524f941609fc0354bc26b87896a72ca6b90f3b628dbd28c05ce3a4041cc6a3fbcbb6997fb3c2293b1e97359b549cdd03580a2298f4c0f685e
+    "@wix/sdk-context": "npm:0.0.1"
+    "@wix/sdk-types": "npm:^1.13.6"
+  checksum: 10c0/e5bf01dcc1cb1ec92a3709df128ffd602821cc7de1b1da17c90f92ef4c2a1f70543e350bcf017560ecb0bb5a6fdaf703c9166669929bc51ef0f8cd1e264c8bac
   languageName: node
   linkType: hard
 
-"@wix/sdk-runtime@npm:^0.3.22, @wix/sdk-runtime@npm:^0.3.33":
-  version: 0.3.33
-  resolution: "@wix/sdk-runtime@npm:0.3.33"
+"@wix/sdk-types@npm:^1.12.4, @wix/sdk-types@npm:^1.13.3, @wix/sdk-types@npm:^1.13.6":
+  version: 1.13.6
+  resolution: "@wix/sdk-types@npm:1.13.6"
   dependencies:
-    "@wix/sdk-context": "npm:^0.0.1"
-    "@wix/sdk-types": "npm:^1.13.3"
-  checksum: 10c0/6816415fabbaf514af09b882f1df28a58bf815f212a6a50d83ae3a53eb3b70914ec9016b5db0e1d5830d4284dd3898fc2f10f65c46a998f13a29eb4a42894115
+    "@wix/monitoring-types": "npm:^0.9.0"
+  checksum: 10c0/af207f33271f59a5f7bc7ca8ac39110ac811edd5b7c4b577edda96813c36382c576905ff518b7d7b3f7bb37bb55469cd74ef6ab576e5be9d692771ebf85db2db
   languageName: node
   linkType: hard
 
-"@wix/sdk-types@npm:^1.12.4, @wix/sdk-types@npm:^1.13.3":
-  version: 1.13.3
-  resolution: "@wix/sdk-types@npm:1.13.3"
-  dependencies:
-    "@wix/monitoring-types": "npm:^0.5.0"
-  checksum: 10c0/b269848cdf63da96d557c11389615dd4771bcbe22584f588f49b47398da2a824a74755eaf1afa44b59150c26a00266479ff19fcf9706f6aa1c4392dbaa74f91b
-  languageName: node
-  linkType: hard
-
-"@wix/sdk@npm:^1.14.3, @wix/sdk@npm:^1.15.9":
-  version: 1.15.10
-  resolution: "@wix/sdk@npm:1.15.10"
+"@wix/sdk@npm:^1.14.3, @wix/sdk@npm:^1.15.14":
+  version: 1.15.14
+  resolution: "@wix/sdk@npm:1.15.14"
   dependencies:
     "@wix/identity": "npm:^1.0.104"
     "@wix/image-kit": "npm:^1.102.0"
     "@wix/redirects": "npm:^1.0.70"
-    "@wix/sdk-context": "npm:^0.0.1"
-    "@wix/sdk-runtime": "npm:0.3.32"
-    "@wix/sdk-types": "npm:^1.13.3"
+    "@wix/sdk-context": "npm:0.0.1"
+    "@wix/sdk-runtime": "npm:0.3.38"
+    "@wix/sdk-types": "npm:^1.13.6"
     graphql: "npm:^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-    jose: "npm:^5.9.6"
-    type-fest: "npm:^4.33.0"
+    jose: "npm:^5.10.0"
+    type-fest: "npm:^4.37.0"
   dependenciesMeta:
     graphql:
       optional: true
-  checksum: 10c0/96a82e413f4d078e07f8b986cc639b1f29bd109e3abf8b2fbeba87d58b9ca64feab0b77223263d47cfa3e722b787ed527575bda6af18bc9528f5858607853ee9
+  checksum: 10c0/f87c148642f527571b5f6c8d23ae1e54b91c4a397c80130fc4b70f4e8c88086e378d38636d37e68a860085074f57343b85ce033781862f95d0984ddba6022389
   languageName: node
   linkType: hard
 
@@ -5395,10 +5384,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jose@npm:^5.9.6":
-  version: 5.9.6
-  resolution: "jose@npm:5.9.6"
-  checksum: 10c0/d6bcd8c7d655b5cda8e182952a76f0c093347f5476d74795405bb91563f7ab676f61540310dd4b1531c60d685335ceb600571a409551d2cbd2ab3e9f9fbf1e4d
+"jose@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "jose@npm:5.10.0"
+  checksum: 10c0/e20d9fc58d7e402f2e5f04e824b8897d5579aae60e64cb88ebdea1395311c24537bf4892f7de413fab1acf11e922797fb1b42269bc8fc65089a3749265ccb7b0
   languageName: node
   linkType: hard
 
@@ -9429,10 +9418,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.21.0, type-fest@npm:^4.33.0":
-  version: 4.34.1
-  resolution: "type-fest@npm:4.34.1"
-  checksum: 10c0/4aa016be91f4225b772d77da91415cd25961a937f84e68d763b2dfeb936ef1671b039bbb0f75019affb8f591c26d65966024343aae75b17ab49db6f9c50c38a8
+"type-fest@npm:^4.21.0, type-fest@npm:^4.37.0":
+  version: 4.37.0
+  resolution: "type-fest@npm:4.37.0"
+  checksum: 10c0/5bad189f66fbe3431e5d36befa08cab6010e56be68b7467530b7ef94c3cf81ef775a8ac3047c8bbda4dd3159929285870357498d7bc1df062714f9c5c3a84926
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Usage example in astrowind [template](https://github.com/wix/headless-templates/blob/dce481dc1bd2a778e09a7fb2a51bcb398f800039/astro/astrowind/src/pages/services.astro#L22):

```html
  <script>
    import { items } from "@wix/data";

    const { items: [servicesData] } = await items
      .query('ServicesPage')
      .find();

    alert(servicesData.heroSubtitle);
  </script>

```