### PR TITLE
We dont force httpOnly anywhere else

### DIFF
--- a/packages/@wix-astro/src/routes/auth/callback.ts
+++ b/packages/@wix-astro/src/routes/auth/callback.ts
@@ -48,7 +48,7 @@ export async function GET({ url, cookies, redirect }: APIContext) {
     cookies.set("wixSession", sessionCookieJson(memberTokens), {
       maxAge: 60 * 60 * 24 * 2,
       path: "/",
-      httpOnly: true,
+      secure: true,
     });
 
     return redirect(originalUrl);


### PR DESCRIPTION
Also we have a client side login that sets the cookie with the tokens.

If we set it here to `httpOnly`, we can't initialize the client site Auth strategy properly, and fail to see the login status and call clientside APIs with the member identity.